### PR TITLE
Issue/#30 - Notify headings adds back screen reader association

### DIFF
--- a/example.json
+++ b/example.json
@@ -2,7 +2,8 @@
 "_visua11y": {
   "_isEnabled": false,
   "_shouldSavePreferences": true,
-  "description": "Use the controls below to customise your learning experience to your individual needs.",
+  "title": "Visua11y",
+  "body": "Use the controls below to customise your learning experience to your individual needs.",
   "_groups": {
     "visualDisplay": "Enhance visual display",
     "distractions": "Reduce distractions",

--- a/example.json
+++ b/example.json
@@ -2,7 +2,7 @@
 "_visua11y": {
   "_isEnabled": false,
   "_shouldSavePreferences": true,
-  "title": "Visua11y",
+  "title": "Accessibility Controls",
   "body": "Use the controls below to customise your learning experience to your individual needs.",
   "_groups": {
     "visualDisplay": "Enhance visual display",

--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -40,7 +40,10 @@ class AnimationsButtonView extends Backbone.View {
 
   onClick(event) {
     if (event && event.preventDefault) event.preventDefault();
+    const config = Adapt.course.get('_visua11y');
     Adapt.visua11y.settingsPrompt = notify.popup({
+      title: config.title,
+      body: config.body,
       _view: new Visua11ySettingsView(),
       _classes: 'is-visua11ysettings',
       _showCloseButton: false

--- a/properties.schema
+++ b/properties.schema
@@ -47,7 +47,15 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
-                "description": {
+                "title": {
+                  "type": "string",
+                  "required": false,
+                  "default": "Accessibility Controls",
+                  "title": "Popup title text",
+                  "inputType": "Text",
+                  "validators": []
+                },
+                "body": {
                   "type": "string",
                   "required": false,
                   "default": "Use the controls below to customise your learning experience to your individual needs.",

--- a/templates/Visua11ySettings.jsx
+++ b/templates/Visua11ySettings.jsx
@@ -21,12 +21,6 @@ export default function Visua11ySettings(config) {
   return (
     <div className='visua11ysettings__inner'>
 
-      {config.description &&
-      <div className='visua11ysettings__description'>
-        {config.description}
-      </div>
-      }
-
       {(config._colorProfile._isEnabled ||
         config._highContrast._isEnabled ||
         config._noTransparency._isEnabled ||

--- a/templates/Visua11ySettings.jsx
+++ b/templates/Visua11ySettings.jsx
@@ -30,7 +30,7 @@ export default function Visua11ySettings(config) {
         <div className='visua11ysettings__group visua11ysettings__group-visualdisplay' role='group' aria-labelledby='visualdisplay'>
           {/* Should 'visua11ysettings__group-title' read as a title or is the lablled list enough? */}
           {config._groups.visualDisplay &&
-          <div className='visua11ysettings__group-title' id='visualdisplay' role="heading" aria-level="3">
+          <div className='visua11ysettings__group-title' id='visualdisplay' role="heading" aria-level="2">
             {config._groups.visualDisplay}
           </div>
           }
@@ -101,7 +101,7 @@ export default function Visua11ySettings(config) {
 
         <div className='visua11ysettings__group visua11ysettings__group-distractions' role='group' aria-labelledby='distractions'>
           {config._groups.distractions &&
-          <div className='visua11ysettings__group-title' id='distractions' role="heading" aria-level="3">
+          <div className='visua11ysettings__group-title' id='distractions' role="heading" aria-level="2">
             {config._groups.distractions}
           </div>
           }
@@ -136,7 +136,7 @@ export default function Visua11ySettings(config) {
 
         <div className='visua11ysettings__group visua11ysettings__group-readability' role='group' aria-labelledby='readability'>
           {config._groups.readability &&
-          <div className='visua11ysettings__group-title' id='readability' role="heading" aria-level="3">
+          <div className='visua11ysettings__group-title' id='readability' role="heading" aria-level="2">
             {config._groups.readability}
           </div>
           }

--- a/templates/Visua11ySettings.jsx
+++ b/templates/Visua11ySettings.jsx
@@ -30,7 +30,7 @@ export default function Visua11ySettings(config) {
         <div className='visua11ysettings__group visua11ysettings__group-visualdisplay' role='group' aria-labelledby='visualdisplay'>
           {/* Should 'visua11ysettings__group-title' read as a title or is the lablled list enough? */}
           {config._groups.visualDisplay &&
-          <div className='visua11ysettings__group-title' id='visualdisplay' role="heading" aria-level="1">
+          <div className='visua11ysettings__group-title' id='visualdisplay' role="heading" aria-level="3">
             {config._groups.visualDisplay}
           </div>
           }
@@ -101,7 +101,7 @@ export default function Visua11ySettings(config) {
 
         <div className='visua11ysettings__group visua11ysettings__group-distractions' role='group' aria-labelledby='distractions'>
           {config._groups.distractions &&
-          <div className='visua11ysettings__group-title' id='distractions' role="heading" aria-level="1">
+          <div className='visua11ysettings__group-title' id='distractions' role="heading" aria-level="3">
             {config._groups.distractions}
           </div>
           }
@@ -136,7 +136,7 @@ export default function Visua11ySettings(config) {
 
         <div className='visua11ysettings__group visua11ysettings__group-readability' role='group' aria-labelledby='readability'>
           {config._groups.readability &&
-          <div className='visua11ysettings__group-title' id='readability' role="heading" aria-level="1">
+          <div className='visua11ysettings__group-title' id='readability' role="heading" aria-level="3">
             {config._groups.readability}
           </div>
           }


### PR DESCRIPTION
This PR ensure a valid label is associated with the accessibility dialog using either aria-label or aria-labelledy with a valid id reference. Currently the notify is referencing the notify-heading which doesn't exist. I've added the notify heading & body to this dialogue so screen readers have that association.

I've additionally removed the 'description' field in favor of the standard notify 'title' & 'body'.

I could use a hand as the visua11y view currently appears BEFORE the notify title & body. It could also use some minor styling as well so the notify heading matches widths with visua11y.
#30