### PR TITLE
#41 Show border on Readability buttons selected state

### DIFF
--- a/less/visua11ySettings.less
+++ b/less/visua11ySettings.less
@@ -127,13 +127,13 @@
       border-radius: 50px;
       background-color: @notify-icon;
       color: @notify-icon-inverted;
-      //border: 1px solid @notify-icon;
+      border: 0.0625rem solid @notify-icon;
     }
 
     input:checked + label .item-text {
       background-color: @notify-icon-hover;
       color: @notify-icon-inverted-hover;
-      //border-color: @notify-icon-inverted-hover;
+      border-color: @notify-icon-inverted-hover;
       //box-shadow: 0 2px 5px fade(@black, 30%);
     }
   }


### PR DESCRIPTION
Fixes #41 

This PR adds a border to the Readability button selected states.

There were already commented out border styles here, so I've uncommented them.  This should resolve the original a11y issue, but I'm not sure why they were commented out in the first place? @kirsty-hames  Looks like you added those styles?

![borders](https://user-images.githubusercontent.com/898168/177418279-e9ff6293-c2c2-4fab-a59a-db7eea74b4e3.jpg)

