### PR TITLE
#44 Fixes No visual keyboard focus on Readability options

### DIFF
--- a/less/visua11ySettings.less
+++ b/less/visua11ySettings.less
@@ -110,6 +110,10 @@
       margin: @item-margin / 2;
     }
 
+    .visua11ysettings__item-option:focus-within {
+      outline: auto;
+    }
+
     input {
       position: absolute;
       top: 0;


### PR DESCRIPTION
fixes #44 

Adds a browser default outline to the Readability options when using the keyboard to navigate.