### PR TITLE
#47 Fixes no Close button configuration option

### DIFF
--- a/example.json
+++ b/example.json
@@ -4,6 +4,7 @@
   "_shouldSavePreferences": true,
   "title": "Accessibility Controls",
   "body": "Use the controls below to customise your learning experience to your individual needs.",
+  "_showCloseButton": false,
   "_groups": {
     "visualDisplay": "Enhance visual display",
     "distractions": "Reduce distractions",

--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -55,9 +55,8 @@ class AnimationsButtonView extends Backbone.View {
 
   onNotifyClicked(event) {
     const $target = $(event.target);
-    const isChild = ($target.parents('.visua11ysettings__inner').length !== 0);
-    const isContainer = $target.is('.visua11ysettings__inner');
-    if (isChild || isContainer) return;
+    const isChild = ($target.parents('.notify__popup-inner').length !== 0);
+    if (isChild) return;
     Adapt.visua11y.settingsPrompt.closeNotify();
   }
 

--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -46,7 +46,7 @@ class AnimationsButtonView extends Backbone.View {
       body: config.body,
       _view: new Visua11ySettingsView(),
       _classes: 'is-visua11ysettings',
-      _showCloseButton: false
+      _showCloseButton: config._showCloseButton || false
     });
     this.render();
     Adapt.visua11y.settingsPrompt.$el.on('click', this.onNotifyClicked);


### PR DESCRIPTION
Fixes #47 

This PR adds an option for `_showCloseButton` that controls whether the close button is shown at the top of the Notify popup.  By default, it will not be shown as is currently the case.

Note that the title/body styles are dependent on PR #46 .  Otherwise, the background area is transparent and too wide.

![close](https://user-images.githubusercontent.com/898168/182230218-4cdd08aa-d7cf-466a-93ba-4cc87f45b328.jpg)
