### PR TITLE
extend no background images support to include Lottie animations

### DIFF
--- a/less/modifiers.less
+++ b/less/modifiers.less
@@ -61,10 +61,14 @@ html[data-color-profile=default] {
 /**
  * Remove img tags with aria-hidden
  * Remove theme background images
+ * Remove svg player with aria-hidden (adapt-svg)
+ * Remove canvas player with aria-hidden (adapt-graphicLottie)
  */
 .a11y-no-background-images {
   img[aria-hidden=true] { display: none }
   .has-bg-image { background-image: none !important; }
+  .svg__player[aria-hidden=true] { display: none; }
+  .graphiclottie__player[aria-hidden=true] { display: none; }
 }
 
 .visua11y-filters {


### PR DESCRIPTION
Both adapt-svg and adapt-graphicLottie provide course content graphics and should be removed when [_noBackgroundImages](https://github.com/cgkineo/adapt-visua11y/blob/db8cfc126f8b01f9c6d72ea34aa73832addcb877/example.json#L60) is enabled if alt text isn't set.

adapt-svg - fixes https://github.com/cgkineo/adapt-svg/issues/18 with https://github.com/cgkineo/adapt-svg/pull/20

adapt-graphicLottie - fixes https://github.com/cgkineo/adapt-graphicLottie/issues/6