### PR TITLE
Update: Add data-order to support navigation sorting (fixes #53)

### DIFF
--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -6,7 +6,8 @@ class AnimationsButtonView extends Backbone.View {
 
   attributes() {
     return {
-      'aria-label': Adapt.visua11y.config._button.navigationAriaLabel
+      'aria-label': Adapt.visua11y.config._button.navigationAriaLabel,
+      'data-order': (Adapt.course.get('_globals')?._extensions?._visua11y?._navOrder || 0)
     };
   }
 

--- a/properties.schema
+++ b/properties.schema
@@ -2,6 +2,15 @@
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
+  "globals": {
+    "_navOrder": {
+      "type": "number",
+      "required": true,
+      "default": 0,
+      "inputType": "Text",
+      "validators": []
+    }
+  },
   "properties": {
     "pluginLocations": {
       "type": "object",


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/53

For consistency with other navigation buttons, Visua11y should support data-order to meet AA accessibility https://github.com/adaptlearning/adapt-contrib-core/pull/61

Unless all navigation buttons support data-order the display order won't be entirely configurable.