### PR TITLE
Fix: Readability padding right override (fixes #57)

### DIFF
--- a/less/visua11ySettings.less
+++ b/less/visua11ySettings.less
@@ -91,6 +91,7 @@
     .visua11ysettings__item {
       display: flex;
       flex-direction: column;
+      padding-right: @item-padding / 2;
 
       @media (min-width: @device-width-medium) {
         flex-direction: row;


### PR DESCRIPTION
Fixes: #57 

### Fix
* Add padding-right override to readability item to widen space available