### PR TITLE
Breaking: update theme bg image selector (fixes #59)

### DIFF
--- a/less/modifiers.less
+++ b/less/modifiers.less
@@ -66,7 +66,7 @@ html[data-color-profile=default] {
  */
 .a11y-no-background-images {
   img[aria-hidden=true] { display: none }
-  .has-bg-image { background-image: none !important; }
+  .has-bg-image > .background { background-image: none !important; }
   .svg__player[aria-hidden=true] { display: none; }
   .graphiclottie__player[aria-hidden=true] { display: none; }
 }

--- a/less/modifiers.less
+++ b/less/modifiers.less
@@ -14,7 +14,7 @@ html:not([data-color-profile=default]) {
       .visua11y-filters;
     }
 
-    .has-bg-image > * {
+    .has-bg-image > .background {
       filter: invert(var(--visua11y-invert));
     }
 
@@ -34,7 +34,7 @@ html[data-color-profile=default] {
       .visua11y-filters-no-profile;
     }
 
-    .has-bg-image > * {
+    .has-bg-image > .background {
       filter: invert(var(--visua11y-invert));
     }
 


### PR DESCRIPTION
'no background images' no longer hides Vanilla and Boxmenu background images since the following amends were made to apply the `background-image` to it's own div.

https://github.com/adaptlearning/adapt-contrib-vanilla/pull/334
https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/119

[modifiers.less](https://github.com/cgkineo/adapt-visua11y/blob/e89f13ec784c1a997f9eec8a9646849f3f62cc8e/less/modifiers.less#L69) just needs updating to target the .background element instead.