### PR TITLE
New: Add html 'a11y-invert' class selector for custom theme styles (fixes #66)

### DIFF
--- a/js/adapt-visua11y.js
+++ b/js/adapt-visua11y.js
@@ -335,6 +335,7 @@ class Visua11y extends Backbone.Controller {
     // Add high contrast html class
     $html
       .toggleClass('a11y-high-contrast', this.highContrast)
+      .toggleClass('a11y-invert', this.invert)
       .toggleClass('a11y-no-animations', this.noAnimations)
       .toggleClass('a11y-no-background-images', this.noBackgroundImages);
     this.rules.forEach(rule => rule.modify(this));


### PR DESCRIPTION
Append `.a11y-invert` to `html` when 'invert' is enabled. Class can be targeted for any overrides or custom styles required in a theme.

Fixes https://github.com/cgkineo/adapt-visua11y/issues/66