### PR TITLE
Fix: Firefox filters (fixes #68)

### DIFF
--- a/assets/visua11y-filters.svg
+++ b/assets/visua11y-filters.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="display:none;">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" aria-hidden="true" style="position:absolute;height:0">
  <defs>
  <filter id="adapt-visua11y-default">
  <feColorMatrix in="SourceGraphic" type="matrix" values="1, 0, 0, 0, 0 0, 1, 0, 0, 0 0, 0, 1, 0, 0 0, 0, 0, 1, 0"/>


### PR DESCRIPTION
fixes #68

### Fix
* Firefox ignores svgs with `style="display:none"`, changed to `style="position:absolute; height:0" aria-hidden="true"`