### PR TITLE
Fix: Added keyword support

### DIFF
--- a/js/COLOR_NAMES.js
+++ b/js/COLOR_NAMES.js
@@ -147,5 +147,10 @@ export default {
   wheat: '#f5deb3',
   whitesmoke: '#f5f5f5',
   yellowgreen: '#9acd32',
-  rebeccapurple: '#663399'
+  rebeccapurple: '#663399',
+  inherit: 'inherit',
+  initial: 'initial',
+  revert: 'revert',
+  'revert-layer': 'revert-layer',
+  unset: 'unset'
 };

--- a/js/CSSRuleModifiers.js
+++ b/js/CSSRuleModifiers.js
@@ -147,6 +147,7 @@ export default [
     function (output) {
       if (!this.highContrast) return;
       const color = Color.parse(output);
+      if (color.isKeyword) return color.source;
       if (color.isTransparent) return;
       // Text: black or white
       if (color.luminance <= 80) {
@@ -164,6 +165,7 @@ export default [
     function (output) {
       if (!this.noTransparency) return;
       const color = Color.parse(output);
+      if (color.isKeyword) return color.source;
       const isTransparent = (color.a <= 0.4);
       if (isTransparent) {
         // No color opacity less than 0.4
@@ -180,6 +182,7 @@ export default [
     Color.parse,
     function (output) {
       let color = Color.parse(output);
+      if (color.isKeyword) return color.source;
       if (color.isTransparent) return color.toRGBAString();
       const colorIndex = this.distinctColors.findIndex(primaryColor => {
         return (color.r === primaryColor.r && color.g === primaryColor.g && color.b === primaryColor.b && color.a === primaryColor.a);

--- a/js/Color.js
+++ b/js/Color.js
@@ -180,6 +180,7 @@ class Color {
   parseCOLORNAME(name) {
     name = name.toLowerCase();
     if (!NAMED_COLOR[name]) throw new Error(`Invalid color: ${name}`);
+    if (this.isKeyword) return this;
     this.parseHEXAString(NAMED_COLOR[name]);
     return this;
   }
@@ -205,6 +206,16 @@ class Color {
 
   get isTransparent() {
     return (this.a === 0);
+  }
+
+  get isKeyword() {
+    return [
+      'inherit',
+      'initial',
+      'revert',
+      'revert-layer',
+      'unset'
+    ].includes(this.source);
   }
 
   /** @returns {Color} */


### PR DESCRIPTION
fixes #77 

### Fix
* Allow 'initial', 'inherit', 'unset', 'revert' and 'revert-layer' to pass-through modification rules

### References
https://developer.mozilla.org/en-US/docs/Web/CSS/computed_value