### PR TITLE
New: Add support for tooltip API (fixes #52)

### DIFF
--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -1,12 +1,14 @@
 import Adapt from 'core/js/adapt';
 import Visua11ySettingsView from './Visua11ySettingsView';
 import notify from 'core/js/notify';
+import tooltips from 'core/js/tooltips';
 
 class AnimationsButtonView extends Backbone.View {
 
   attributes() {
     return {
-      'aria-label': Adapt.visua11y.config._button.navigationAriaLabel
+      'aria-label': Adapt.visua11y.config._button.navigationAriaLabel,
+      'data-tooltip-id': 'visua11y'
     };
   }
 
@@ -28,6 +30,11 @@ class AnimationsButtonView extends Backbone.View {
     this.onNotifyClosed = this.onNotifyClosed.bind(this);
     this.onNotifyClicked = this.onNotifyClicked.bind(this);
     this.render();
+    
+    tooltips.register({
+      _id: 'visua11y',
+      ...Adapt.course.get('_globals')?._extensions?._visua11y?._navTooltip || {}
+    });
   }
 
   render() {

--- a/js/Visua11yButtonView.js
+++ b/js/Visua11yButtonView.js
@@ -8,6 +8,7 @@ class AnimationsButtonView extends Backbone.View {
   attributes() {
     return {
       'aria-label': Adapt.visua11y.config._button.navigationAriaLabel,
+      'data-order': (Adapt.course.get('_globals')?._extensions?._visua11y?._navOrder || 0),
       'data-tooltip-id': 'visua11y'
     };
   }

--- a/properties.schema
+++ b/properties.schema
@@ -27,7 +27,7 @@
           "default": "Visual accessibility settings",
           "help": "The tooltip text to display on hover over this item",
           "inputType": "Text",
-          "validators": []
+          "validators": [],
           "translatable": true
         }
       }

--- a/properties.schema
+++ b/properties.schema
@@ -2,6 +2,30 @@
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
+  "globals": {
+    "_navTooltip": {
+      "type": "object",
+      "title": "Navigation tooltip",
+      "default": {},
+      "properties": {
+        "_isEnabled": {
+          "type": "boolean",
+          "default": true,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Enabled?"
+        },
+        "text": {
+          "type": "string",
+          "title": "",
+          "default": "Settings",
+          "inputType": "Text",
+          "required": true,
+          "translatable": true
+        }
+      }
+    }
+  },
   "properties": {
     "pluginLocations": {
       "type": "object",

--- a/properties.schema
+++ b/properties.schema
@@ -5,22 +5,22 @@
   "globals": {
     "_navTooltip": {
       "type": "object",
-      "title": "Navigation tooltip",
-      "default": {},
+      "title": "Visua11y navigation tooltip",
       "properties": {
         "_isEnabled": {
           "type": "boolean",
           "default": true,
+          "title": "Enable tooltip for navigation button",
           "inputType": "Checkbox",
-          "validators": [],
-          "title": "Enabled?"
+          "validators": []
         },
         "text": {
           "type": "string",
           "title": "",
-          "default": "Settings",
+          "default": "Visual accessibility settings",
+          "help": "The tooltip text to display on hover over this item",
           "inputType": "Text",
-          "required": true,
+          "validators": []
           "translatable": true
         }
       }


### PR DESCRIPTION
Fixes #52 

For consistency with core navigation buttons when tooltips are enabled. Ref: https://github.com/adaptlearning/adapt-contrib-core/pull/207

## Testing the PR
You need to enable Adapt tooltips in _course.json_:
```
  "_tooltips": {
    "_isEnabled": true
  }
```

And use the following config to enable the Visua11y tooltip in _course.json_ (nesting within `_globals` `_extensions`):
```
      "_visua11y": {
        "_navTooltip": {
          "_isEnabled": true,
          "text": "Visual accessibility settings"
        }
      }
```
Note, we haven't updated an extension to support the tooltip API as of yet so I've based the config for this on how the core nav buttons are currently configured, but happy to take steer on this.

I haven't tested this in the AAT as we're not officially supporting this yet.