### PR TITLE
Fix: _highContrastLuminanceThreshold as string (fixes #99)

### DIFF
--- a/js/ColorTransformations.js
+++ b/js/ColorTransformations.js
@@ -2,6 +2,7 @@ import Color from './Color';
 import FILTERS from './COLOR_FILTERS';
 
 const HIGH_CONTRAST = ({ _highContrastLuminanceThreshold }) => {
+  _highContrastLuminanceThreshold = parseFloat(_highContrastLuminanceThreshold);
   return [
     [0, 10, 0], // Move 0-10 to 0
     [10, _highContrastLuminanceThreshold + 1, 10, 30, false], // For 10-71 (not inclusive) move towards 10 not more than 30


### PR DESCRIPTION
fixes #99

If `_highContrastLuminanceThreshold` is defined as a string `"70"` in the json, rather than a number `70`, the high contrast calculations will not be applied properly, converting all bright colours to 30% darkness.

### Fix
* Converts `_highContrastLuminanceThreshold` to a number
