### PR TITLE
Update: Add paragraph spacing instruction (fixes #102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ It provides visual accessibility improvements.
 ### Note
 * IE11 cannot apply filters. This means that images and videos will not be transformed in IE11.
 * All colour transformations are applied by mathematical shifts. It is therefore important that the course start from AA colour contrast for the algorithms to be applicable.
-* Line height, paragraph spacing, letter spacing and word spacing are all ratio based. 1 is the current value, 1.2 is and uplift by 20%, 0.9 would be a shift downwards by 10%.
-* Font size medium is the default font size (16px usually), large is 18pt, small is 9pt.
 * Invert only inverts brightness, not colour.
+* Line height, paragraph spacing, letter spacing and word spacing are all ratio based. 1 is the current value, 1.2 is and uplift by 20%, 0.9 would be a shift downwards by 10%.
+* In order to support paragraph spacing, all body text needs to be wrapped in [paragraph tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
+* Font size medium is the default font size (16px usually), large is 18pt, small is 9pt.
 * Hide decorative images is contingent on alt text.
 
 ----------------------------

--- a/properties.schema
+++ b/properties.schema
@@ -634,7 +634,8 @@
                       "default": true,
                       "title": "Enable",
                       "inputType": "Checkbox",
-                      "validators": []
+                      "validators": [],
+                      "help": "Note, in order to support paragraph spacing, all body text needs to be wrapped in paragraph '<p>' tags"
                     },
                     "title": {
                       "type": "string",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -472,6 +472,7 @@
             "_paragraphSpacing": {
               "type": "object",
               "title": "Paragraph spacing",
+              "description": "Note, in order to support paragraph spacing, all body text needs to be wrapped in paragraph '<p>' tags",
               "default": {},
               "properties": {
                 "_isEnabled": {


### PR DESCRIPTION
To support paragraph spacing, all body text needs to be wrapped in `<p>` tags.

Schemas and README updated.

Fixes https://github.com/cgkineo/adapt-visua11y/issues/102