### PR TITLE
Fix: Title is required to set notify popup dialog label (fixes #107)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -94,7 +94,7 @@
                 },
                 "title": {
                   "type": "string",
-                  "required": false,
+                  "required": true,
                   "default": "Accessibility Controls",
                   "title": "Popup title text",
                   "inputType": "Text",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -77,6 +77,9 @@
           "type": "object",
           "title": "Visua11y",
           "default": {},
+          "required": [
+            "title"
+          ],
           "properties": {
             "_isEnabled": {
               "type": "boolean",


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/107

### Fix
* Set `title` as `required`. Without a title, the popup `dialog` won't be properly identified by assistive technologies.



