### PR TITLE
Update: remove legacy nav btn float (fixes #111)

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -1,5 +1,4 @@
 .nav__visua11y-btn {
-  .u-float-right;
   .icon {
     .icon-visua11y-accessibility;
   }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/111

### Update
The nav button [float](https://github.com/cgkineo/adapt-visua11y/blob/f952a6516e1ecaa2ad1ccdea544d3cd6a4299469/less/buttons.less#L2) style is no longer required since the plugin was updated to support [`data-order`](https://github.com/cgkineo/adapt-visua11y/pull/93).

Core also [overrides](https://github.com/adaptlearning/adapt-contrib-core/blob/8b36e3ee68941b62e711198f49fa9345c1758132/less/core/nav.less#L38) any `.nav__btn` `float` styles. 