### PR TITLE
Update: remove text-shadow + box-shadow when 'No Transparency' enabled (fixes #73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It provides visual accessibility improvements.
 * In order to support paragraph spacing, all body text needs to be wrapped in [paragraph tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
 * Font size medium is the default font size (16px usually), large is 18pt, small is 9pt.
 * Hide decorative images is contingent on alt text.
+* No transparency removes `box-shadow`, `text-shadow` and `opacity` styles.
 
 ### Theme considerations
 * All colour transformations are applied by mathematical shifts. It is therefore important that the course start from AA colour contrast for the algorithms to be applicable.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It provides visual accessibility improvements.
 * In order to support paragraph spacing, all body text needs to be wrapped in [paragraph tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
 * Font size medium is the default font size (16px usually), large is 18pt, small is 9pt.
 * Hide decorative images is contingent on alt text.
-* No transparency removes `box-shadow`, `text-shadow` and `opacity` styles.
+* No transparency removes `box-shadow` (where transparency is used), `text-shadow` and `opacity` styles.
 
 ### Theme considerations
 * All colour transformations are applied by mathematical shifts. It is therefore important that the course start from AA colour contrast for the algorithms to be applicable.

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/cgkineo/adapt-visua11y.git"
   },
-  "version": "2.8.2",
+  "version": "2.9.0",
   "framework": ">=5.31.4",
   "homepage": "https://github.com/cgkineo/adapt-visua11y",
   "issues": "https://github.com/cgkineo/adapt-visua11y/issues/new",

--- a/js/CSSRuleModifiers.js
+++ b/js/CSSRuleModifiers.js
@@ -26,11 +26,13 @@ export default [
     }
   ],
   [
-    // Remove box shadows
+    // Remove box shadows with transparency
     'box-shadow',
     null,
-    function () {
+    function (output) {
       if (!this.noTransparency) return;
+      const zeroOffsetAndBlur = '0px 0px 0px';
+      if (output.includes(zeroOffsetAndBlur)) return;
       return 'none';
     }
   ],

--- a/js/CSSRuleModifiers.js
+++ b/js/CSSRuleModifiers.js
@@ -17,6 +17,15 @@ import Color from './Color';
  */
 export default [
   [
+    // Remove text shadows
+    'text-shadow',
+    null,
+    function () {
+      if (!this.noTransparency) return;
+      return 'none';
+    }
+  ],
+  [
     // Remove box shadows
     'box-shadow',
     null,

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -1,5 +1,4 @@
 .nav__visua11y-btn {
-  .u-float-right;
   .icon {
     .icon-visua11y-accessibility;
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/cgkineo/adapt-visua11y.git"
   },
-  "version": "2.8.2",
+  "version": "2.9.0",
   "framework": ">=5.31.4",
   "homepage": "https://github.com/cgkineo/adapt-visua11y",
   "issues": "https://github.com/cgkineo/adapt-visua11y/issues/new",


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/73

### Update
* When 'No Transparency' is enabled, remove `box-shadow` styles containing transparency. Meaning, where `box-shadow` has an offset and/or blur value, to create a drop shadow effect for example. A zero offset and blur displays as a solid border (no transparency) so there's no reason to remove this. Quite often `box-shadow` is used in favour of `border` or `outline` as it offers more flexibility styling.

### New
* When 'No Transparency' enabled, remove `text-shadow` styles.


### Testing
1. Install Visua11y. Copy the [example](https://github.com/cgkineo/adapt-visua11y/blob/98bbb4f381afcc02eb0101e0799fa129a4810866/example.json#L13) config into _course.json_ and enable.
2. Add some `box-shadow` and `text-shadow` styles to your theme. For example:
```
.page__title {
  text-shadow: red 2px 5px;
}
.hotgraphic__pin {
  box-shadow: 10px 5px 5px red;
}
```
3. Confirm styles have been applied in your course.
4. Enable 'No Transparency' in Visually settings.
5. Review course to confirm styles have been removed.



