### PR TITLE
Fix: Remove important from icon font declaration (fixes #118)

### DIFF
--- a/less/icons.less
+++ b/less/icons.less
@@ -24,8 +24,7 @@
 }
 
 .icon-visua11y {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: '@{icomoon-font-family}' !important;
+  font-family: '@{icomoon-font-family}';
   speak: never;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
fixes #118 

### Fix
* Removed important to allow easy reassignment of icon

