### PR TITLE
Update: Replace dialog button aria-expanded with aria-haspopup dialog (fixes #129)

### DIFF
--- a/js/Visua11yNavigationButtonView.js
+++ b/js/Visua11yNavigationButtonView.js
@@ -46,6 +46,9 @@ class Visua11yNavigationButtonView extends NavigationButtonView {
   }
 
   setupEventListeners() {
+    const config = Adapt.course.get('_visua11y');
+    if (config._location === 'drawer') return;
+    
     this.onNotifyClosed = this.onNotifyClosed.bind(this);
     this.onNotifyClicked = this.onNotifyClicked.bind(this);
   }

--- a/js/Visua11yNavigationButtonView.js
+++ b/js/Visua11yNavigationButtonView.js
@@ -16,7 +16,7 @@ class Visua11yNavigationButtonView extends NavigationButtonView {
       'data-order': attributes._order,
       'aria-label': Adapt.visua11y.config._button.navigationAriaLabel,
       'data-tooltip-id': 'visua11y',
-      'aria-expanded': false
+      'aria-haspopup': 'dialog'
     };
   }
 
@@ -46,13 +46,6 @@ class Visua11yNavigationButtonView extends NavigationButtonView {
   }
 
   setupEventListeners() {
-    const config = Adapt.course.get('_visua11y');
-
-    if (config._location === 'drawer') {
-      this.listenTo(Adapt, 'drawer:closed', this.onDrawerClosed);
-      return;
-    };
-
     this.onNotifyClosed = this.onNotifyClosed.bind(this);
     this.onNotifyClicked = this.onNotifyClicked.bind(this);
   }
@@ -75,7 +68,6 @@ class Visua11yNavigationButtonView extends NavigationButtonView {
     }
     this.render();
     Adapt.trigger('visua11y:opened');
-    this.$el.attr('aria-expanded', true);
   }
 
   onNotifyClicked(event) {
@@ -86,13 +78,8 @@ class Visua11yNavigationButtonView extends NavigationButtonView {
     Adapt.visua11y.settingsPrompt.closeNotify();
   }
 
-  onDrawerClosed() {
-    this.$el.attr('aria-expanded', false);
-  }
-
   onNotifyClosed(notify) {
     if (notify !== Adapt.visua11y.settingsPrompt) return;
-    this.$el.attr('aria-expanded', false);
     Adapt.visua11y.settingsPrompt.$el.off('click', this.onNotifyClicked);
     Adapt.visua11y.settingsPrompt = null;
     this.stopListening(Adapt, 'notify:closed', this.onNotifyClosed);


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/129

### Update
The navigation button that triggers a dialog to open (Drawer or Notify), the button `aria-expanded` has been replaced with `aria-haspopup="dialog"`.  Please refer to the [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/657) for the research and discussion supporting this change.

### Testing
Navigate to the Visua11y button in the nav bar using a screen reader. Depending on the browser/screen reader used, expect the following reading....

VoiceOver “Visual accessibility settings, dialog pop-up, button”
NVDA “Visual accessibility settings, button opens dialog”
JAWS “Visual accessibility settings, button has popup dialog”

Tested with the following combinations:
VoiceOver Safari macOS and iPhone
VoiceOver Chrome and Firefox macOS
JAWS Chrome, Edge and Firefox Windows
NVDA Chrome, Edge and Firefox Windows