### PR TITLE
Update: Update html target selector from element to class (fix #128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It provides visual accessibility improvements.
 * Letter spacing (small, medium, large)
 * Word spacing (small, medium, large)
 
-### Note
-* IE11 cannot apply filters. This means that images and videos will not be transformed in IE11.
+## Note
+
 * Invert only inverts brightness, not colour.
 * Line height, paragraph spacing, letter spacing and word spacing are all ratio based. 1 is the current value, 1.2 is and uplift by 20%, 0.9 would be a shift downwards by 10%.
 * In order to support paragraph spacing, all body text needs to be wrapped in [paragraph tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
@@ -25,19 +25,22 @@ It provides visual accessibility improvements.
 * Hide decorative images is contingent on alt text.
 * No transparency removes `box-shadow` (where transparency is used), `text-shadow` and `opacity` styles.
 
-### Theme considerations
+## Theme considerations
+
 * All colour transformations are applied by mathematical shifts. It is therefore important that the course start from AA colour contrast for the algorithms to be applicable.
 * Any custom CSS `background-image` will need to explicitly define support for colour profiles. For example:
-<pre>
+
+```less
 html:not([data-color-profile=default]) {
   .selector-with-css-bg-image {
     .visua11y-filters;
   }
 }
-</pre>
+```
+
 * For any text that overlays a background image, ensure an appropriate `background-color` is set to provide sufficient contrast in the instance decorative images are hidden (`"_noBackgroundImages": false`).
 
 ----------------------------
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/cgkineo/adapt-visua11y/graphs/contributors)<br/>
 **Accessibility support:** WAI AA<br/>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br/>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/less/modifiers.less
+++ b/less/modifiers.less
@@ -2,10 +2,9 @@
  * Apply svg filter to img, video, canvas, svg and mejs-poster to match the text/color changes.
 
  * Note:
- * Applies filters to body children and notify children separately as filter affects fixed position elements
- * Filters do not work in ie11
+ * Applies filters to body children and notify children separately as filter affects fixed position elementsie11
  */
-html:not([data-color-profile=default]) {
+.html:not([data-color-profile=default]) {
 
   body > *:not(.notify),
   .notify > * {
@@ -21,7 +20,7 @@ html:not([data-color-profile=default]) {
 /**
  * Exclude filter url when on default profile
  */
-html[data-color-profile=default] {
+.html[data-color-profile=default] {
 
   body > *:not(.notify),
   .notify > * {

--- a/less/normalise.less
+++ b/less/normalise.less
@@ -1,14 +1,14 @@
 /**
  * Apply white background to app for inversion later
  */
-html {
+.html {
   background-color: white;
 }
 
 /**
  * Normalise styles for later modification
  */
-html, button {
+.html, button {
   line-height: normal;
   letter-spacing: normal;
   word-spacing: normal;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/cgkineo/adapt-visua11y.git"
   },
   "version": "2.12.1",
-  "framework": ">=5.31.4",
+  "framework": ">=5.46.4",
   "homepage": "https://github.com/cgkineo/adapt-visua11y",
   "issues": "https://github.com/cgkineo/adapt-visua11y/issues/new",
   "extension": "visua11y",


### PR DESCRIPTION
Update #128 

### Update
* Update <html> target selector from element `html` to class `.html`
* Bumps required FW version to [5.46.4](https://github.com/adaptlearning/adapt_framework/releases/tag/v5.46.4) for Core [6.60.13](https://github.com/adaptlearning/adapt-contrib-core/releases/tag/v6.60.13) dependency
* Remove IE 11 references from Less and _README.md_
* Update _README.md_ for markdownlint issues