### PR TITLE
Fix: Preserve url() values in background-image rules (fix #141)

### DIFF
--- a/js/Colors.js
+++ b/js/Colors.js
@@ -4,7 +4,7 @@ import COLOR_NAMES from './COLOR_NAMES';
 const SPECIFIC_NAMES = Object.entries(COLOR_NAMES)
   .filter(([name, value]) => name !== value)
   .map(([name]) => name);
-const COLOR_MATCH = new RegExp(`(?:rgb|hsl)\\([^)]+\\)|(?:rgba|hsla)\\([^)]+\\)|#[\\da-f]{3,8}|${SPECIFIC_NAMES.join('|')}`, 'gmi');
+const COLOR_MATCH = new RegExp(`url\\([^)]*\\)|(?:rgb|hsl)\\([^)]+\\)|(?:rgba|hsla)\\([^)]+\\)|#[\\da-f]{3,8}|${SPECIFIC_NAMES.join('|')}`, 'gmi');
 
 /**
  * For parsing and modifying css "func(color, color)" strings
@@ -17,7 +17,9 @@ export default class Colors {
   }
 
   get distinctColors() {
-    const allColors = this.parts.map(part => Color.parse(part[0]).toRGBAString());
+    const allColors = this.parts
+      .filter(part => !/^url\(/i.test(part[0]))
+      .map(part => Color.parse(part[0]).toRGBAString());
     const distinctColors = _.uniq(allColors).map(Color.parse);
     return distinctColors;
   }
@@ -41,8 +43,12 @@ export default class Colors {
       const end = nextPart.index;
       output += String(this.source).slice(start, end);
       if (nextPart[0]) {
-        const color = Color.parse(nextPart[0]);
-        output += color.applyTransparency(context);
+        if (/^url\(/i.test(nextPart[0])) {
+          output += nextPart[0];
+        } else {
+          const color = Color.parse(nextPart[0]);
+          output += color.applyTransparency(context);
+        }
       } else if (start <= end) {
         output += String(this.source).slice(nextPart.index, this.source.length);
       }
@@ -70,8 +76,12 @@ export default class Colors {
       const end = nextPart.index;
       output += String(this.source).slice(start, end);
       if (nextPart[0]) {
-        const color = Color.parse(nextPart[0]);
-        output += color.applyColorProfile(context);
+        if (/^url\(/i.test(nextPart[0])) {
+          output += nextPart[0];
+        } else {
+          const color = Color.parse(nextPart[0]);
+          output += color.applyColorProfile(context);
+        }
       } else if (start <= end) {
         output += String(this.source).slice(nextPart.index, this.source.length);
       }


### PR DESCRIPTION
Fixes #141.

## Problem

CSS color names appearing as substrings inside `url()` values (e.g. `url("logo-white.png")`) were being rewritten to their `rgba()` equivalents (`url("logo-rgba(255,255,255,1).png")`), breaking image paths.

Root cause: `COLOR_MATCH` regex in `Colors.js` matched color names anywhere in the string, including inside `url()` tokens. `Color.applyColorProfile()` then normalised matched names to `rgba()` even on the default profile.

## Fix

In [`js/Colors.js`](js/Colors.js):

- Add `url\([^)]*\)` as first alternative in `COLOR_MATCH` so `url()` values are captured as whole tokens before color-name matching can occur inside them.
- In `applyTransparency`, `applyColorProfile`, and `distinctColors`, pass through `url()` tokens unchanged.

## Test plan

- [ ] Confirm bug reproduces in `master` with `background-image: url("assets/logo-white.png")` in custom CSS, visua11y enabled, default profile.
- [ ] Apply fix and confirm filename remains intact.
- [ ] Verify non-default profiles still transform actual color values correctly.
- [ ] Confirm gradients with color values (e.g. `linear-gradient(red, blue)`) still transform as before.
- [ ] Confirm backgrounds with both url and color (`url("logo.png") red`) preserve url and transform color.

Test image - _logo-white.png_
<img width="200" alt="logo-white" src="https://github.com/user-attachments/assets/c0f02a1c-a9c6-40bf-aa72-d156f90b8806" />

Posted via collaboration with Claude Code