### PR TITLE
Fix: Hide img tags with empty alt attribute (fixes #143)

### DIFF
--- a/less/modifiers.less
+++ b/less/modifiers.less
@@ -51,12 +51,14 @@
 
 /**
  * Remove img tags with aria-hidden
+ * Remove img tags with empty alt attributes
  * Remove theme background images
  * Remove svg player with aria-hidden (adapt-svg)
  * Remove canvas player with aria-hidden (adapt-graphicLottie)
  */
 .a11y-no-background-images {
   img[aria-hidden=true] { visibility: hidden; }
+  img[alt=""] { visibility: hidden; }
   .has-bg-image > .background { background-image: none !important; }
   .svg__player[aria-hidden=true] { display: none; }
   .graphiclottie__player[aria-hidden=true] { display: none; }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-visua11y/issues/143

### Fix
* Extend 'hide decorative images' support to empty alt attributes. 

Decorative images were previously defined in Adapt by `aria-hidden`. Since decorative images are now defined by their empty alt attribute (`alt=""`) visua11y was no longer hiding these when `_noBackgroundImages` was enabled.

Relates to Adapt PR https://github.com/adaptlearning/adapt-contrib-core/pull/825

### Testing
1. Using a course with Visua11y installed and enabled. Ensure the course contains content graphics with no alt text.
2. Open Visua11y settings and enable 'hide decorative images'. Content graphic with no alt text should be visually hidden.
3. Content graphics with alt text remain visible.



